### PR TITLE
added blinking and font color to role information (BE: [*NO BACKEND*])

### DIFF
--- a/src/app/game/[gameCode]/play/RoleInformation.tsx
+++ b/src/app/game/[gameCode]/play/RoleInformation.tsx
@@ -19,11 +19,16 @@ export default function RoleInformation({ role }: Props) {
 
     const formattedRole = role.replace(/_/g, " ");
 
+    const roleClassName =
+        role === "IMPOSTOR" || role === "IMPOSTOR_GHOST"
+            ? "text-red-600"
+            : "text-white";
+
     return (
         <div className="roleInformation bg-black text-white border border-gray-600 shadow-md rounded-lg p-4 font-sans text-sm w-full max-w-md mb-8">
             <div className="flex items-center border-b border-gray-400 mb-2 pb-2">
                 <p className="text-2xl font-semibold">Role:</p>
-                <p className={`ml-2 text-2xl font-bold ${isBlinking ? 'animate-blink' : ''}`}>
+                <p className={`ml-2 text-2xl font-bold ${roleClassName} ${isBlinking ? 'animate-blink' : ''}`}>
                     {formattedRole}
                 </p>
             </div>

--- a/src/app/game/[gameCode]/play/RoleInformation.tsx
+++ b/src/app/game/[gameCode]/play/RoleInformation.tsx
@@ -1,18 +1,32 @@
+import { useEffect, useState } from "react";
 import { Role } from "@/app/types";
 
 type Props = {
-  role: Role;
+    role: Role;
 };
 
 export default function RoleInformation({ role }: Props) {
-  const formattedRole = role.replace(/_/g, " ");
+    const [isBlinking, setIsBlinking] = useState(false);
 
-  return (
-    <div className="roleInformation bg-black text-white border border-gray-600 shadow-md rounded-lg p-4 font-sans text-sm w-full max-w-md mb-8">
-      <div className="flex items-center border-b border-gray-400 mb-2 pb-2">
-        <p className="text-lg font-semibold">Role:</p>
-        <p className="ml-2 text-lg font-semibold">{formattedRole}</p>
-      </div>
-    </div>
-  );
+    useEffect(() => {
+        setIsBlinking(true);
+        const timer = setTimeout(() => {
+            setIsBlinking(false);
+        }, 5000);
+
+        return () => clearTimeout(timer);
+    }, [role]);
+
+    const formattedRole = role.replace(/_/g, " ");
+
+    return (
+        <div className="roleInformation bg-black text-white border border-gray-600 shadow-md rounded-lg p-4 font-sans text-sm w-full max-w-md mb-8">
+            <div className="flex items-center border-b border-gray-400 mb-2 pb-2">
+                <p className="text-2xl font-semibold">Role:</p>
+                <p className={`ml-2 text-2xl font-bold ${isBlinking ? 'animate-blink' : ''}`}>
+                    {formattedRole}
+                </p>
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
- role information starts blinking for 5 seconds when role changes or at start of the game
- role information font color either white or red based on role (i.e.: crewmate or impostor)